### PR TITLE
feat: autoredeploy dev instance on merges into master  

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,3 +64,6 @@ workflows:
           requires:
             - lint
             - test
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,12 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: |
-          git config user.email "$DEPLOY_COMMIT_EMAIL"
-          git config user.name "$DEPLOY_COMMIT_USERNAME"
-          yarn deploy
+      - run:
+          name: Deploy dev instance
+          command: |
+            git config user.email "$DEPLOY_COMMIT_EMAIL"
+            git config user.name "$DEPLOY_COMMIT_USERNAME"
+            yarn deploy
 workflows:
   version: 2
   lint_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - add_ssh_keys:
+          fingerpints:
+            - "3a:a2:25:c4:65:34:db:a5:f6:45:14:b4:23:78:5b:38"
       - run:
           name: Deploy dev instance
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             yarn deploy
 workflows:
   version: 2
-  lint_test_deploy:
+  build:
     jobs:
       - install-dependencies
       - lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: yarn deploy
+      - run: |
+          git config user.email "$DEPLOY_COMMIT_EMAIL"
+          git config user.name "$DEPLOY_COMMIT_USERNAME"
+          yarn deploy
 workflows:
   version: 2
   lint_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,16 @@ jobs:
       - attach_workspace:
             at: .
       - run: yarn test
+  deploy:
+    executor: ci-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: yarn deploy
 workflows:
   version: 2
-  lint_and_test:
+  lint_test_deploy:
     jobs:
       - install-dependencies
       - lint:
@@ -45,3 +52,7 @@ workflows:
       - test:
           requires:
             - install-dependencies
+      - deploy:
+          requires:
+            - lint
+            - test


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/MjKgNctX)

# Problem statement

Dev instance can be deployed only manually and can be outdated. It's cool to automatically redeploy dev instance on merges into master

# Steps to test the changes

Check CI config. Merge anything into master, ensure that dev instance was redeployed with this changes.

# Solution description

Change CircleCI config

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and do not break the app

# Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions
- [x] The solution description matches the changes in the code
- [x] There is no apparent way to improve the performance & design of the new code
