### PR TITLE
Fix: labelled input focus on outside click

### DIFF
--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -15,6 +15,7 @@ function App() {
             label="Добавить заказ №"
             type="number"
             inputClassName="order-id-input"
+            centered
           />
         </h1>
         <main>

--- a/src/components/labelled-date-input/LabelledDateInput.css
+++ b/src/components/labelled-date-input/LabelledDateInput.css
@@ -2,6 +2,10 @@
   right: 0;
 }
 
+.labelled-date-input__label {
+  display: flex;
+}
+
 .labelled-date-input__input {
   width: 150px;
   padding: 5px;

--- a/src/components/labelled-input/LabelledInput.css
+++ b/src/components/labelled-input/LabelledInput.css
@@ -1,3 +1,13 @@
+.labelled-input__label {
+  width: fit-content;
+  max-width: 100%;
+  display: block;
+}
+
+.labelled-input__label--centered {
+  margin: 0 auto;
+}
+
 .labelled-input__input {
   width: 150px;
   padding: 5px;

--- a/src/components/labelled-input/LabelledInput.css
+++ b/src/components/labelled-input/LabelledInput.css
@@ -23,7 +23,3 @@
 .labelled-input__input--invalid {
   border: 2px solid red;
 }
-
-.labelled-date-input__label {
-  display: flex;
-}

--- a/src/components/labelled-input/LabelledInput.jsx
+++ b/src/components/labelled-input/LabelledInput.jsx
@@ -12,13 +12,21 @@ const LabelledInput = ({
   labelClassName,
   onChange,
   invalid,
+  centered,
   ...other
 }) => {
+  const labelClasses = classNames(
+    'labelled-input__label',
+    {
+      'labelled-input__label--centered': centered,
+    },
+    labelClassName
+  )
   const inputClasses = classNames('labelled-input__input', inputClassName, {
     'labelled-input__input--invalid': invalid,
   })
   return (
-    <label className={labelClassName}>
+    <label className={labelClasses}>
       {label}{' '}
       {renderInput ? (
         renderInput()
@@ -44,6 +52,7 @@ LabelledInput.propTypes = {
   renderInput: PropTypes.func,
   onChange: PropTypes.func,
   invalid: PropTypes.bool,
+  centered: PropTypes.bool,
 }
 
 LabelledInput.defaultProps = {
@@ -54,6 +63,7 @@ LabelledInput.defaultProps = {
   renderInput: null,
   onChange: () => {},
   invalid: false,
+  centered: false,
 }
 
 export default LabelledInput

--- a/src/components/labelled-input/LabelledInput.stories.jsx
+++ b/src/components/labelled-input/LabelledInput.stories.jsx
@@ -18,6 +18,7 @@ const getComponent = (props) => {
 
 storiesOf('LabelledInput', module)
   .add('simple', () => getComponent())
+  .add('centered', () => getComponent({ centered: true }))
   .add('with default value', () =>
     getComponent({ defaultValue: 'Super test default value' })
   )

--- a/src/components/product/Product.css
+++ b/src/components/product/Product.css
@@ -34,7 +34,6 @@
 }
 
 .product__inputs > label {
-  display: block;
   margin-bottom: 15px;
 }
 

--- a/src/components/product/Product.jsx
+++ b/src/components/product/Product.jsx
@@ -9,7 +9,12 @@ export default function Product() {
       <div className="product__close-wrapper">
         <i className="icon-close product__close" />
       </div>
-      <LabelledInput label="Имя товара" inputClassName="name-input" disabled />
+      <LabelledInput
+        label="Имя товара"
+        inputClassName="name-input"
+        disabled
+        centered
+      />
       <span className="product__type">Тип товара</span>
       <section className="product__buttons-wrapper">
         <button
@@ -67,17 +72,20 @@ export default function Product() {
           label="Закупочная цена товара"
           inputClassName="purchase-price-input"
           required
+          centered
         />
         <LabelledInput
           label="Цена товара"
           inputClassName="price-input"
           required
+          centered
         />
         <LabelledInput
           label="Количество товаров"
           inputClassName="number-input"
           defaultValue="1"
           type="number"
+          centered
         />
       </div>
       <LabelledInput
@@ -90,6 +98,7 @@ export default function Product() {
             className="comment-area"
           />
         )}
+        centered
       />
     </section>
   )


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/JJiBbwyW)

# Problem statement

LabelledInput is clickable outside of the visible label and input area

# Steps to test the changes

Steps to reproduce:
Click a bit to the right of the input of LabelledInput.
Actual result: input focuses.
Expected result: nothing happens.

# Solution description

Apply `width: fit-content` to the label. It breaks centering in some places, thus add align prop to LabelledInput.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and do not break the app

# Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions
- [ ] The solution description matches the changes in the code
- [ ] There is no apparent way to improve the performance & design of the new code
