### PR TITLE
Remove should from tests' and story notes' names

### DIFF
--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -295,4 +295,27 @@ describe('App', () => {
 })
 ```
 
-That's all project code style rules, that we have!
+## Names of it blocks
+
+Do not add `should` to test names. It's just redundant.
+Because of it first verb in the name should be in the 3rd form 
+
+Incorrect:
+```js
+it('should work', () => {
+  expect(true).toBe(true)
+});
+
+it('work', () => {
+  expect(true).toBe(true)
+}); 
+```
+
+Correct:
+```js
+it('works', () => {
+  expect(true).toBe(true)
+}); 
+```
+
+That's all project code style rules, that we have. Enjoy!

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -220,15 +220,15 @@ Put blank line between describe and it blocks in tests:
 Incorrect:
 ```js
 describe('sum', () => {
-  it('should sum numbers', () => {
+  it('sums numbers', () => {
     expect(sum(2, 2)).toBe(4)
   })
-  it('should sum other numbers', () => {
+  it('sums other numbers', () => {
     expect(sum(2,3)).toBe(5)
   })
 })
 describe('subtract', () => {
-  it('should subtract numbers', () => {
+  it('subtracts numbers', () => {
     expect(subtract(2,2)).toBe(0)
   })
 })
@@ -237,17 +237,17 @@ describe('subtract', () => {
 Correct:
 ```js
 describe('sum', () => {
-  it('should sum numbers', () => {
+  it('sums numbers', () => {
     expect(sum(2, 2)).toBe(4)
   })
 
-  it('should sum other numbers', () => {
+  it('sums other numbers', () => {
     expect(sum(2,3)).toBe(5)
   })
 })
 
 describe('subtract', () => {
-  it('should subtract numbers', () => {
+  it('subtracts numbers', () => {
     expect(subtract(2,2)).toBe(0)
   })
 })

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -253,7 +253,7 @@ describe('subtract', () => {
 })
 ```
 
-## Names in strings of describe blocks
+## Names of describe blocks
 
 Please use only function or component name in describe string
 

--- a/src/components/app/App.test.jsx
+++ b/src/components/app/App.test.jsx
@@ -25,18 +25,18 @@ describe('App', () => {
 
   afterEach(() => ReactDOM.unmountComponentAtNode(container))
 
-  it('should render without crashing', () => {
+  it('renders without crashing', () => {
     render()
   })
 
-  it('should render products', () => {
+  it('renders products', () => {
     render({
       products: [{ id: 1 }, { id: 2 }, { id: 3 }],
     })
     expect(querySelectorAll('.products > *')).toHaveLength(3)
   })
 
-  it('should render 0 products', () => {
+  it('renders 0 products', () => {
     render({
       products: [],
     })
@@ -44,7 +44,7 @@ describe('App', () => {
   })
 
   it(
-    'should call addProduct callback on click on add product button ' +
+    'calls addProduct callback on click on add product button ' +
       'without arguments',
     () => {
       const onAddProduct = jest.fn()

--- a/src/components/button/Button.test.jsx
+++ b/src/components/button/Button.test.jsx
@@ -26,27 +26,27 @@ describe('Button', () => {
 
   afterEach(() => ReactDOM.unmountComponentAtNode(container))
 
-  it('should render one button element', () => {
+  it('renders one button element', () => {
     render()
     expect(querySelectorAll('button')).toHaveLength(1)
   })
 
-  it('should pass additional classes to the element', () => {
+  it('passes additional classes to the element', () => {
     render({ className: 'awesome-button' })
     expect(getElement().classList.contains('awesome-button')).toBe(true)
   })
 
-  it('should pass any other passed props to the tag', () => {
+  it('passes any other passed props to the tag', () => {
     render({ id: 'nice-button' })
     expect(getElement().getAttribute('id')).toBe('nice-button')
   })
 
-  it('should render children as text', () => {
+  it('renders children as text', () => {
     render({ children: 'test content' })
     expect(getElement().innerHTML).toBe('test content')
   })
 
-  it('should render children as node', () => {
+  it('renders children as node', () => {
     render({ children: <span>text</span> })
     expect(getElement().innerHTML).toBe('<span>text</span>')
   })

--- a/src/components/labelled-input/LabelledInput.stories.jsx
+++ b/src/components/labelled-input/LabelledInput.stories.jsx
@@ -23,7 +23,7 @@ storiesOf('LabelledInput', module)
     getComponent({ defaultValue: 'Super test default value' })
   )
   .add('with number type', () => getComponent({ type: 'number' }), {
-    notes: 'should render short input with type=number',
+    notes: 'renders short input with type=number',
   })
   .add(
     'with custom render function',
@@ -37,7 +37,7 @@ storiesOf('LabelledInput', module)
         ),
       }),
     {
-      notes: 'should render select',
+      notes: 'renders select',
     }
   )
   .add(
@@ -49,7 +49,7 @@ storiesOf('LabelledInput', module)
         },
       }),
     {
-      notes: 'should render red border around input',
+      notes: 'renders red border around input',
     }
   )
   .add('if has invalid data', () =>
@@ -64,6 +64,6 @@ storiesOf('LabelledInput', module)
         label: <h1>Test</h1>,
       }),
     {
-      notes: 'should render h1 tag',
+      notes: 'renders h1 tag',
     }
   )

--- a/src/components/utils/withClassName/withClassName.test.jsx
+++ b/src/components/utils/withClassName/withClassName.test.jsx
@@ -16,14 +16,14 @@ describe('withClassName', () => {
     return container.childNodes[0]
   }
 
-  it('should pass className to the underlying component', () => {
+  it('passes className to the underlying component', () => {
     const EnhancedComponent = withClassName(SimpleComponent, 'test-class')
     render({ Component: EnhancedComponent })
     expect(getElement().classList).toHaveLength(1)
     expect(getElement().classList.contains('test-class')).toBe(true)
   })
 
-  it('should pass all other props to the underlying component', () => {
+  it('passes all other props to the underlying component', () => {
     const EnhancedComponent = withClassName(SimpleComponent, 'test')
     render({
       Component: EnhancedComponent,

--- a/src/reducers/products_reducer.test.js
+++ b/src/reducers/products_reducer.test.js
@@ -2,32 +2,32 @@ import reducer, { getMaximumProductId } from './products_reducer'
 import { addProduct, removeProduct } from '../actions'
 
 describe('products reducer', () => {
-  it('should return the initial state', () => {
+  it('returns the initial state', () => {
     const expected = [{ id: 1 }]
     expect(reducer(undefined, {})).toEqual(expected)
   })
 
-  it('should handle addProduct action', () => {
+  it('handles addProduct action', () => {
     const actual = reducer([{ id: 1 }], addProduct())
     const expected = [{ id: 1 }, { id: 2 }]
     expect(actual).toEqual(expected)
   })
 
-  it('should correctly handle addProduct action with complex state', () => {
+  it('handles addProduct action with complex state', () => {
     const state = [{ id: 1 }, { id: 3 }]
     const actual = reducer(state, addProduct())
     const expected = [{ id: 1 }, { id: 3 }, { id: 4 }]
     expect(actual).toEqual(expected)
   })
 
-  it('should handle removeProduct action', () => {
+  it('handles removeProduct action', () => {
     const state = [{ id: 1 }, { id: 2 }]
     const actual = reducer(state, removeProduct(1))
     const expected = [{ id: 2 }]
     expect(actual).toEqual(expected)
   })
 
-  it('should handle removeProduct action 2', () => {
+  it('handles removeProduct action 2', () => {
     const state = [{ id: 1 }, { id: 2 }, { id: 5 }]
     const actual = reducer(state, removeProduct(2))
     const expected = [{ id: 1 }, { id: 5 }]
@@ -36,16 +36,16 @@ describe('products reducer', () => {
 })
 
 describe('getMaximumProductId', () => {
-  it('should return maximum product id for 1 product', () => {
+  it('returns maximum product id for 1 product', () => {
     expect(getMaximumProductId([{ id: 1 }])).toBe(1)
   })
 
-  it('should return maximum product id for 2 products', () => {
+  it('returns maximum product id for 2 products', () => {
     const products = [{ id: 10 }, { id: 20 }]
     expect(getMaximumProductId(products)).toBe(20)
   })
 
-  it('should return maximum product id for 5 products', () => {
+  it('returns maximum product id for 5 products', () => {
     const products = [
       { id: 2 },
       { id: 10 },


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/zlp5Sjxn)

# Problem statement

Redundant `should` word in all tests' and story notes' names

# Steps to test the changes

Run `yarn test`. Type `t`, type some test's name, ensure that it looks good. Read new docs

# Solution description

Remove `should` from tests' and story notes' names. Add note about tests' names to README

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and do not break the app

# Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions
- [ ] The solution description matches the changes in the code
- [ ] There is no apparent way to improve the performance & design of the new code
