### PR TITLE
Chore: allow imports in any order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,7 @@
         "devDependencies": ["**/*.stories.jsx"]
       }
     ],
-    "jest-formatting/padding-around-expect-groups": "off"
+    "jest-formatting/padding-around-expect-groups": "off",
+    "import/order": "off"
   }
 }

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -55,22 +55,6 @@ const jsx = <input type="text">
 }
 ```
 
-## Import order
-
-Please firstly import node modules and next any project files:
-
-Incorrect:
-```js
-import App from './app'
-import classNames from 'classnames'
-```
-
-Correct:
-```js
-import classNames from 'classnames'
-import App from './app'
-``` 
-
 ## JSX only in .jsx files
 
 Please write jsx only in files with extension `jsx`


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/uXvW1LGa)

# Problem statement

Linter dislikes, when you import node module after project file

# Steps to test the changes

Try to put import of project file above node module import. Verify that eslint doesn't complain about it.

# Solution description

change eslint config. Remove import order block from readme.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and do not break the app

# Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions
- [ ] The solution description matches the changes in the code
- [ ] There is no apparent way to improve the performance & design of the new code
