### PR TITLE
Chore: report prettier errors as warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,5 +63,6 @@ module.exports = {
     //  this rule reports them as unused, what is incorrect.
     //  Currently unused prop types are reported by react-redux plugin.
     //  Which can correctly handle such case.
+    'prettier/prettier': 'warn',
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,11 +57,11 @@ module.exports = {
     'import/order': 'off',
     'react-redux/prefer-separate-component-file': 'off',
     'react/no-unused-prop-types': 'off',
-  //  this doesn't mean we allow unused prop types.
-  //  we need to disable this rule to allow prop types,
-  //  which are used only in mapDispatchToProps or mapStateToProps.
-  //  this rule reports them as unused, what is incorrect.
-  //  Currently unused prop types are reported by react-redux plugin.
-  //  Which can correctly handle such case.
+    //  this doesn't mean we allow unused prop types.
+    //  we need to disable this rule to allow prop types,
+    //  which are used only in mapDispatchToProps or mapStateToProps.
+    //  this rule reports them as unused, what is incorrect.
+    //  Currently unused prop types are reported by react-redux plugin.
+    //  Which can correctly handle such case.
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,5 +64,7 @@ module.exports = {
     //  Currently unused prop types are reported by react-redux plugin.
     //  Which can correctly handle such case.
     'prettier/prettier': 'warn',
+    //  we allow 0 warnings, so don't think prettier rules are ignored
+    // this is only to show prettier issues as warnings, not errors
   },
 }


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/o21PNQsg/47-report-prettier-errors-as-warnings)

# Problem statement

Eslint reports prettier errors as errors. But it's just minor style issues. It's better to report them as warnings. And it's safe, as we allow 0 warnings.

# Steps to test the changes

Add prettier error somewhere. Verify eslint reports it as warning.

# Solution description

Reconfigure eslint.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and do not break the app

# Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions
- [x] The solution description matches the changes in the code
- [x] There is no apparent way to improve the performance & design of the new code
