### PR TITLE
Fix issue, when UI removes all products

### DIFF
--- a/src/reducers/products_reducer.js
+++ b/src/reducers/products_reducer.js
@@ -12,6 +12,9 @@ const initialState = {
 }
 
 function getMaximumProductId(products) {
+  if (!products.length) {
+    return 0
+  }
   const ids = products.map((product) => product.id)
   return Math.max(...ids)
 }

--- a/src/reducers/products_reducer.test.js
+++ b/src/reducers/products_reducer.test.js
@@ -86,6 +86,10 @@ describe('chooseTypeReducer', () => {
 })
 
 describe('getMaximumProductId', () => {
+  it('returns 0 if array of products is empty', () => {
+    expect(getMaximumProductId([])).toBe(0)
+  })
+
   it('returns maximum product id for 1 product', () => {
     expect(getMaximumProductId([createMockProduct(1)])).toBe(1)
   })


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/0bH1ef1x/40-all-products-are-removed-on-click-on-remove-product)

# Problem statement

Decided how to get next ID if all products are removed

# Steps to test the changes

if pass an argument, the getMaximumProductId function equal to [] returns 0 

# Solution description

check item.length to array of roducts

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and do not break the app

# Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions
- [ ] The solution description matches the changes in the code
- [ ] There is no apparent way to improve the performance & design of the new code
